### PR TITLE
fix: ensure Vault mounts are created first

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,7 @@ resource "vault_kv_secret_v2" "secrets_wo" {
   name                 = try(each.value.name, each.key)
   data_json_wo         = each.value.json
   data_json_wo_version = each.value.version
+  depends_on           = [vault_mount.mounts]
 }
 
 resource "vault_policy" "policy" {


### PR DESCRIPTION
This avoids this kind of error:
  * no handler for route "myproject/data/mainnet/mainnet-myproject-validator-0". route entry not found.